### PR TITLE
Cancel plugin if target div does not exist

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -82,16 +82,9 @@ periodConfig.init();
 appManager.applyTo(arrayTo(api));
 optionConfig.applyTo(arrayTo(api));
 
-const isTargetDiv = elId => !!document.getElementById(elId);
-
-const logNoTargetDiv = (id, name) => {
-    console.log(`Event chart suspended (${id}, ${name})`);
-};
-
 // plugin
 function render(plugin, layout) {
-    if (!isTargetDiv(layout.el)) {
-        logNoTargetDiv(layout.id, layout.name || layout.displayName);
+    if (!util.dom.validateTargetDiv(layout.el)) {
         return;
     }
 
@@ -118,8 +111,7 @@ function render(plugin, layout) {
 
     // instance manager
     instanceManager.setFn(function(_layout) {
-        if (!isTargetDiv(_layout.el)) {
-            logNoTargetDiv(_layout.id, _layout.name || _layout.displayName);
+        if (!util.dom.validateTargetDiv(_layout.el)) {
             return;
         }
 
@@ -159,6 +151,10 @@ function render(plugin, layout) {
     if (layout.id) {
         instanceManager.getById(layout.id, function(_layout) {
             _layout = new api.Layout(instanceRefs, objectApplyIf(layout, _layout));
+
+            if (!util.dom.validateTargetDiv(_layout.el)) {
+                return;
+            }
 
             instanceManager.getReport(_layout);
         });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -82,8 +82,19 @@ periodConfig.init();
 appManager.applyTo(arrayTo(api));
 optionConfig.applyTo(arrayTo(api));
 
+const isTargetDiv = elId => !!document.getElementById(elId);
+
+const logNoTargetDiv = (id, name) => {
+    console.log(`Event chart suspended (${id}, ${name})`);
+};
+
 // plugin
 function render(plugin, layout) {
+    if (!isTargetDiv(layout.el)) {
+        logNoTargetDiv(layout.id, layout.name || layout.displayName);
+        return;
+    }
+
     var instanceRefs = Object.assign({}, refs);
 
     // ui manager
@@ -107,6 +118,11 @@ function render(plugin, layout) {
 
     // instance manager
     instanceManager.setFn(function(_layout) {
+        if (!isTargetDiv(_layout.el)) {
+            logNoTargetDiv(_layout.id, _layout.name || _layout.displayName);
+            return;
+        }
+
         var el = _layout.el;
         var element = document.getElementById(el);
         var response = _layout.getResponse();


### PR DESCRIPTION
Checks if the target element exists:
- immediately after being called
- before fetching data
- before render

If the target element does not exist at any of these points in time just stop the process.