### PR TITLE
Upgrade d2-analysis to get latest interpretations mentions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/dhis2/event-charts-app#readme",
   "dependencies": {
-    "d2-analysis": "31.0.4",
+    "d2-analysis": "32.0.2",
     "d2-charts-api": "29.0.1",
     "d2-utilizr": "0.2.13"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,10 +1294,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d2-analysis@31.0.4:
-  version "31.0.4"
-  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-31.0.4.tgz#cc5d6a8d2a08f26726d914ee5cbc56277e387474"
-  integrity sha512-Bn47br+4X5tj9l0pLiepCSKiD/wJX1MoRM74Gd99KXHk5tyIWPONZSwiOnyVfgWMkRCcjIg0i9hjVpATvfGpSg==
+d2-analysis@32.0.2:
+  version "32.0.2"
+  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-32.0.2.tgz#4a803cd0ea614f8a6fca94c8989b388726e29084"
+  integrity sha512-c4UVfk87cjCOenU8AQ4xW3r3yS+O2ZxHtFu18zbfkDIZlxGYYU0YgQ4J26r/t7NQmyl/z61A4THLsT3pUXEm5w==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^5.1.0"
     d2-utilizr "^0.2.16"


### PR DESCRIPTION
The latest d2-analysis package will limit the number of mentions to 5, in the interpretations
Fixes [DHIS2-5483]

