### PR TITLE
fix(push-analytics): add push analytics instructions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "validate": "npm ls --depth 0",
     "prestart": "d2-manifest package.json manifest.webapp",
     "start": "webpack-dev-server",
-    "build": "rm -rf build && webpack --config webpack.config.prod.js && cp ./index.html build && cp ./jquery*.min.js build && cp -r i18n build && cp -r dhis2 build && cp -r extjs build && npm run manifest",
+    "build": "rm -rf build && webpack --config webpack.config.prod.js && cp ./index.html build && cp ./push-analytics.json build && cp ./jquery*.min.js build && cp -r i18n build && cp -r dhis2 build && cp -r extjs build && npm run manifest",
     "manifest": "d2-manifest package.json build/manifest.webapp"
   },
   "repository": {

--- a/push-analytics.json
+++ b/push-analytics.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.0.1",
+    "showVisualization": {
+        "strategy": "navigateToUrl",
+        "steps": [
+            { "goto": "{{appUrl}}?id={{id}}" },
+            { "waitForSelector": "svg.highcharts-root" }
+        ]
+    },
+    "triggerDownload": {
+        "strategy": "useUiElements",
+        "steps": [
+            { "click": ".push-analytics-download-dropdown-menu-button" },
+            { "click": ".push-analytics-download-as-png-menu-item" }
+        ]
+    },
+    "obtainDownloadArtifact": {
+        "strategy": "interceptFileDownload"
+    },
+    "clearVisualization": {
+        "strategy": "useUiElements",
+        "steps": [
+            { "click": ".push-analytics-favorites-dropdown-menu-button" },
+            { "click": ".push-analytics-new-events-chart-menu-item" }
+        ]
+    }
+}


### PR DESCRIPTION
Related to [DHIS2-15367](https://dhis2.atlassian.net/browse/DHIS2-15367) in JIRA and push-analytics [PR#10](https://github.com/dhis2/push-analytics/pull/10)

---

### Key features

1. Adds a JSON file with scrape instructions which push-analytics can use to convert a dashboard item for this app.
2. During the build process this file is copied to root directory of the app

---



[DHIS2-15367]: https://dhis2.atlassian.net/browse/DHIS2-15367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ