### PR TITLE
fix: add push analytics cls [2.41.0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # event-charts-app
 DHIS 2 app for event data visualization
 
-Latest compatible version of d2-analysis: `33.1.0-ev.1`
+Latest compatible version of d2-analysis: `33.1.0-ev.3`

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/dhis2/event-charts-app#readme",
   "dependencies": {
-    "d2-analysis": "33.1.0-ev.1",
+    "d2-analysis": "33.1.0-ev.3",
     "d2-charts-api": "29.0.1",
     "d2-utilizr": "0.2.13"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,10 +1303,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d2-analysis@33.1.0-ev.1:
-  version "33.1.0-ev.1"
-  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-33.1.0-ev.1.tgz#fd3c21645f62c52431e73bc2ecb2da3204c7d94f"
-  integrity sha512-a1LzXYK9BaQmSMA/VklHdz7CN/UMneYFCTaeY93hzV4BF2Bd19L6IzTEA2WSEE3khUzpJ0C2JPcF9D0eYcC+Wg==
+d2-analysis@33.1.0-ev.3:
+  version "33.1.0-ev.3"
+  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-33.1.0-ev.3.tgz#3f3ba374aeca54c22b2c07d1adb517a068cc96e4"
+  integrity sha512-jAJYTFnu1xgnNZNy1ATPNXUg9gsn/4/Ezx47TC+wR5qXY15eIJ8kAcMm4VEQmviSdic13I5TT4y1UkPTLZGmWg==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^5.1.0"
     d2-utilizr "^0.2.16"


### PR DESCRIPTION
Adds the cls from the patch that was left out.