### PR TITLE
fix: migrate from user credentials, calendar manager race condition (DHIS2-19206)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/dhis2/event-charts-app#readme",
   "dependencies": {
-    "d2-analysis": "33.1.0-ev.4",
+    "d2-analysis": "33.1.0-ev.5",
     "d2-charts-api": "29.0.1",
     "d2-utilizr": "0.2.13"
   },
@@ -64,7 +64,7 @@
       "dhis": {
         "href": "..",
         "auth": "admin:district",
-        "devHref": "http://localhost:8080"
+        "devHref": "https://test.e2e.dhis2.org/analytics-dev"
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1303,10 +1303,10 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d2-analysis@33.1.0-ev.4:
-  version "33.1.0-ev.4"
-  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-33.1.0-ev.4.tgz#7eb18a22510ee616a5d150a4827077c57431f62d"
-  integrity sha512-GbMCPkAT9gM0LZ0yram7lctxe4ixJX+IWfyhQNJT3vZUVccYQNI9bGZqHG8hpTzaMYr2BWtW675idnTb0hTaRQ==
+d2-analysis@33.1.0-ev.5:
+  version "33.1.0-ev.5"
+  resolved "https://registry.yarnpkg.com/d2-analysis/-/d2-analysis-33.1.0-ev.5.tgz#c2ae1657ea73a7c00d88d724fa0a59234c9402b3"
+  integrity sha512-ddXoIt7HAWCAliKih+C7eIi/gMAO2gWQ0HMbOMX4U3NZnCMeKbWU+HCQeGMhCVK2YEWP1rBgZvSYQaXnJCzHOg==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^5.1.0"
     d2-utilizr "^0.2.16"


### PR DESCRIPTION
Ports https://github.com/dhis2/d2-analysis/pull/150 and https://github.com/dhis2/d2-analysis/commit/0af48e977675985ad37281bbc8844edd2bd47164 to EV compatible version of d2-analysis.